### PR TITLE
Adjusting input type for giphyService.giphy()

### DIFF
--- a/src/commands/gifs/giphy/giphy.service.ts
+++ b/src/commands/gifs/giphy/giphy.service.ts
@@ -11,11 +11,8 @@ export class GiphyService {
 
   }
 
-  async giphy(message: Message, gifSearchString: string[]): Promise<void> {
-    let searchString = '';
-    await gifSearchString.forEach((word) => {
-      searchString = searchString.concat(`${word} `);
-    });
+  async giphy(message: Message, gifSearchString: string): Promise<void> {
+    let searchString = gifSearchString;
     this.giphyToken = await String(process.env.GIPHY_TOKEN);
     const giphyFetch = await new GiphyFetch(this.giphyToken);
     await giphyFetch.search(searchString)


### PR DESCRIPTION
### Overview

Quick bugfix to change the input of `giphyService.giphy()` from `string[]` to `string`. This was necessary due to the new parsing done on the command string by the `listenerService`.